### PR TITLE
Update Find-VulnerableLog4J.ps1

### DIFF
--- a/deploy/Find-VulnerableLog4J.ps1
+++ b/deploy/Find-VulnerableLog4J.ps1
@@ -85,11 +85,9 @@ try {
             "'$_'"
         }) -join ' '
     }
-    $ScanGroups | ForEach-Object {
+    $ScanGroups | Where-Object { -not [string]::IsNullOrEmpty($_) } | ForEach-Object {
         Invoke-Expression "& '$castPath' scan $_" | ForEach-Object {
-            if (-not [string]::IsNullOrEmpty($_)) {
-                $_ | Out-File -Append -FilePath $OutputPath -Encoding ASCII
-            }
+            $_ | Out-File -Append -FilePath $OutputPath -Encoding ASCII
             if ($_ -match $JavaClassFilter) {
                 Write-Output $_
             }


### PR DESCRIPTION
Replaced $FilesToScan with $ScanGroups, which splits the $Files array into an array of containing strings with 20 file path values. This causes cast.exe to scan 20 file paths at a time, which should avoid errors caused by string limitations.