### PR TITLE
Updated ExpectedHash of cast.exe to match the current sha256 hash of …

### DIFF
--- a/deploy/Find-VulnerableLog4J.ps1
+++ b/deploy/Find-VulnerableLog4J.ps1
@@ -32,7 +32,7 @@ $JavaClassFilter = "(JmsAppender|JndiManager|NetUtils)"
 try {
     $castPath = Join-Path $TempDirectoryPath "cast.exe"
     $OutputPath = Join-Path $TempDirectoryPath "cast_results.json"
-    $ExpectedHash = "86FE23EAF103F69DA6D81ED95CF2418185DC879B00D8D22156B1496E4DD0FEFA"
+    $ExpectedHash = "3185231d6fba2b25ec863becbea38ae1b2c4f613aca6b2589080903762c7f4a2"
 
     if ((Test-Path -Path $castPath) -eq $false) {
         # Check that cast.exe is present in same directory as script


### PR DESCRIPTION
…the windows release.

Updated the Powershell script to have the correct sha256 hash of the extracted cast.exe verison 0.6.3.

Posted hash for .zip file in cast_0.6.2_Windows_amd64.zip.sha256 : "e5d06f16bb57bc89934563c183f6293148445ed2067f63a849235f541eacd02b  cast_0.6.2_Windows_amd64.zip"

Calculated sha256 hash of cast_0.6.2_Windows_amd64.zip : "e5d06f16bb57bc89934563c183f6293148445ed2067f63a849235f541eacd02b"

Calculated hash of cast.exe : "3185231d6fba2b25ec863becbea38ae1b2c4f613aca6b2589080903762c7f4a2"

I figure if people are using Powershell for this, they're probably using the windows version of cast.exe so updating the hash to match may be helpful. 