### PR TITLE
Discard invalid paths

### DIFF
--- a/deploy/Find-VulnerableLog4J.ps1
+++ b/deploy/Find-VulnerableLog4J.ps1
@@ -57,9 +57,21 @@ try {
     }
     $Directories += (Get-Process | Where-Object { $_.Path }).Path | Split-Path
     $Directories = $Directories | Sort-Object -Unique
-    Write-Output "`nSearching $(($Directories | Measure-Object).Count) directories..."
-    for ($i = 0; $i -lt ($Directories | Measure-Object).Count; $i += 20) {
-        [string] $Group = ($Directories[$i..($i + 19)] | Where-Object { -not [string]::IsNullOrEmpty($_) } |
+
+    $ValidDirectories = New-Object System.Collections.Generic.List[string]
+
+    foreach($path in $Directories){
+        if (Test-Path $path){
+            $ValidDirectories.Add($path)
+        }else{
+            Write-Warning "Invalid Path: $Path"
+        }
+
+    }
+    
+    Write-Output "`nSearching $(($ValidDirectories | Measure-Object).Count) directories..."
+    for ($i = 0; $i -lt ($ValidDirectories | Measure-Object).Count; $i += 20) {
+        [string] $Group = ($ValidDirectories[$i..($i + 19)] | Where-Object { -not [string]::IsNullOrEmpty($_) } |
             ForEach-Object { ,"'$($_.TrimEnd('\'))'" }) -join ' '
         if ($Group) {
             Invoke-Expression "& '$castPath' scan $Group" | ForEach-Object {

--- a/deploy/Find-VulnerableLog4J.ps1
+++ b/deploy/Find-VulnerableLog4J.ps1
@@ -56,22 +56,11 @@ try {
         }
     }
     $Directories += (Get-Process | Where-Object { $_.Path }).Path | Split-Path
-    $Directories = $Directories | Sort-Object -Unique
-
-    $ValidDirectories = New-Object System.Collections.Generic.List[string]
-
-    foreach($path in $Directories){
-        if (Test-Path $path){
-            $ValidDirectories.Add($path)
-        }else{
-            Write-Warning "Invalid Path: $Path"
-        }
-
-    }
+    $Directories = $Directories | Sort-Object -Unique | Where-Object { Test-Path $_ -EA SilentlyContinue }
     
-    Write-Output "`nSearching $(($ValidDirectories | Measure-Object).Count) directories..."
-    for ($i = 0; $i -lt ($ValidDirectories | Measure-Object).Count; $i += 20) {
-        [string] $Group = ($ValidDirectories[$i..($i + 19)] | Where-Object { -not [string]::IsNullOrEmpty($_) } |
+    Write-Output "`nSearching $(($Directories | Measure-Object).Count) directories..."
+    for ($i = 0; $i -lt ($Directories | Measure-Object).Count; $i += 20) {
+        [string] $Group = ($Directories[$i..($i + 19)] | Where-Object { -not [string]::IsNullOrEmpty($_) } |
             ForEach-Object { ,"'$($_.TrimEnd('\'))'" }) -join ' '
         if ($Group) {
             Invoke-Expression "& '$castPath' scan $Group" | ForEach-Object {


### PR DESCRIPTION
If the installation registry keys have invalid paths, I've experienced some issues with the execution of cast.exe.

This addition to the PowerShell script tests to see if the discovered path exists, prior to running CAST.
If the path does not exist, it discards the path.